### PR TITLE
Add searching functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@mui/icons-material": "^5.3.1",
         "@mui/material": "^5.4.0",
         "@next-auth/sequelize-adapter": "^1.0.2",
+        "fuse.js": "^6.5.3",
         "next": "12.0.10",
         "next-auth": "^4.2.1",
         "pg": "^8.7.1",
@@ -2776,6 +2777,14 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "node_modules/fuse.js": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.5.3.tgz",
+      "integrity": "sha512-sA5etGE7yD/pOqivZRBvUBd/NaL2sjAu6QuSaFoe1H2BrJSkH/T/UXAJ8CdXdw7DvY3Hs8CXKYkDWX7RiP5KOg==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -7168,6 +7177,11 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "fuse.js": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.5.3.tgz",
+      "integrity": "sha512-sA5etGE7yD/pOqivZRBvUBd/NaL2sjAu6QuSaFoe1H2BrJSkH/T/UXAJ8CdXdw7DvY3Hs8CXKYkDWX7RiP5KOg=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@mui/icons-material": "^5.3.1",
     "@mui/material": "^5.4.0",
     "@next-auth/sequelize-adapter": "^1.0.2",
+    "fuse.js": "^6.5.3",
     "next": "12.0.10",
     "next-auth": "^4.2.1",
     "pg": "^8.7.1",

--- a/src/pages/api/anime/search/index.ts
+++ b/src/pages/api/anime/search/index.ts
@@ -1,10 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import Fuse from 'fuse.js'
-import { getAllReleases, ReleaseList, ReleaseWithType, ShowWithTitle } from '../../../../utils/dbQueries'
+import { getAllReleases, ReleaseWithType, ShowWithTitle } from '../../../../utils/dbQueries'
 
 export default async function handler(
     req: NextApiRequest,
-    res: NextApiResponse<ReleaseList | { id: string } | Fuse.FuseResult<{
+    res: NextApiResponse<Fuse.FuseResult<{
         show: ShowWithTitle;
         releases: ReleaseWithType[];
     }>[]>

--- a/src/pages/api/anime/search/index.ts
+++ b/src/pages/api/anime/search/index.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import Fuse from 'fuse.js'
+import { getAllReleases, ReleaseList, ReleaseWithType, ShowWithTitle } from '../../../../utils/dbQueries'
+
+export default async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse<ReleaseList | { id: string } | Fuse.FuseResult<{
+        show: ShowWithTitle;
+        releases: ReleaseWithType[];
+    }>[]>
+) {
+    switch (req.method) {
+    case 'GET': {
+        const releases = await getAllReleases()
+        const fuseOptions = {
+            keys: ['show.id', 'show.titles.title']
+        }
+        const fuse = new Fuse(releases, fuseOptions)
+        const results = fuse.search(req.query.q as string)
+        res.json(results)
+        break
+    }
+    default:
+        res.setHeader('Allow', 'GET')
+        res.status(405).end(`Method ${req.method} Nodt Allowed`)
+        break
+    }
+}


### PR DESCRIPTION
This PR adds a simple search endpoint that can be accessed at `/api/anime/search?q=`.

This might be useful later when implementing the torznab meme. Currently it uses [fuse.js](https://fusejs.io/), however, I believe a comparison between this method and the performance of a simple SQL search -> fuse fuzzy search should be done. Returning the entire sneedox and then fuzzy searching it seems like it may be an expensive query/task, but then again searching via SQL will probably be just as expensive, if not more.